### PR TITLE
Replace docker assert with stretchr assert

### DIFF
--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/pkg/testutil/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTimeTransform(t *testing.T) {


### PR DESCRIPTION
The old outdated package github.com/docker/docker/pkg/testutil/assert causes dependency errors in other projects. Using stretchr fixes that problem.